### PR TITLE
Make sdk setting for apple builds selectable by name

### DIFF
--- a/gn/skia/BUILD.gn
+++ b/gn/skia/BUILD.gn
@@ -17,18 +17,21 @@ declare_args() {
   malloc = ""
   werror = false
   xcode_sysroot = ""
+  sdk = ""
 }
 
 if (is_ios && xcode_sysroot == "") {
-  if (is_tvos) {
-    sdk = "appletvos"
-    if (target_cpu == "x86" || target_cpu == "x64") {
-      sdk = "appletvsimulator"
-    }
-  } else {
-    sdk = "iphoneos"
-    if (target_cpu == "x86" || target_cpu == "x64") {
-      sdk = "iphonesimulator"
+  if(sdk == "") {
+    if (is_tvos) {
+      sdk = "appletvos"
+      if (target_cpu == "x86" || target_cpu == "x64") {
+        sdk = "appletvsimulator"
+      }
+    } else {
+      sdk = "iphoneos"
+      if (target_cpu == "x86" || target_cpu == "x64") {
+        sdk = "iphonesimulator"
+      }
     }
   }
   xcode_sysroot =


### PR DESCRIPTION
Instead of guessing based on architecture make the SDK selectable by name

This helps not having to pass the full SDK path to gn, just to build the armv8 iphonesimulator version