### PR TITLE
use correct flags for ios simulator min version

### DIFF
--- a/gn/skia/BUILD.gn
+++ b/gn/skia/BUILD.gn
@@ -233,9 +233,15 @@ config("default") {
                ] + _arch_flags
     libs += [ "objc" ]
     if (ios_min_target != "") {
-      cflags += [ "-miphoneos-version-min=$ios_min_target" ]
-      asmflags += [ "-miphoneos-version-min=$ios_min_target" ]
-      ldflags += [ "-miphoneos-version-min=$ios_min_target" ]
+      if(sdk == "iphonesimulator") {
+        cflags += [ "-mios-simulator-version-min=$ios_min_target" ]
+        asmflags += [ "-mios-simulator-version-min=$ios_min_target" ]
+        ldflags += [ "-mios-simulator-version-min=$ios_min_target" ]
+      } else {
+        cflags += [ "-miphoneos-version-min=$ios_min_target" ]
+        asmflags += [ "-miphoneos-version-min=$ios_min_target" ]
+        ldflags += [ "-miphoneos-version-min=$ios_min_target" ]
+      }
     }
   }
 


### PR DESCRIPTION
without this, whenever you specify a min ios version and try to compile for the simulator it will still generate ios binaries